### PR TITLE
Zero profiling

### DIFF
--- a/libraries/mathy_python/mathy/agents/a3c/config.py
+++ b/libraries/mathy_python/mathy/agents/a3c/config.py
@@ -11,6 +11,8 @@ class A3CConfig(BaseConfig):
     #   syncing the latest model from the learner process.
     update_gradients_every: int = 64
 
+    normalization_style: str = "layer"
+
     # How many times to think about the initial state before acting.
     # (intuition) is that the LSTM updates the state each time it processes
     # the init sequence meaning that it gets more time to fine-tune the hidden

--- a/libraries/mathy_python/mathy/agents/base_config.py
+++ b/libraries/mathy_python/mathy/agents/base_config.py
@@ -18,6 +18,11 @@ class BaseConfig(BaseModel):
     url: str = about.__uri__
     mathy_version: str = f">={about.__version__},<1.0.0"
 
+    # One of "batch" or "layer"
+    normalization_style = "batch"
+
+    # Whether to use the LSTM or non-reccurrent architecture
+    use_lstm: bool = True
     units: int = 64
     embedding_units: int = 128
     lstm_units: int = 128

--- a/libraries/mathy_python/mathy/agents/base_config.py
+++ b/libraries/mathy_python/mathy/agents/base_config.py
@@ -19,7 +19,7 @@ class BaseConfig(BaseModel):
     mathy_version: str = f">={about.__version__},<1.0.0"
 
     # One of "batch" or "layer"
-    normalization_style = "batch"
+    normalization_style = "layer"
 
     # Whether to use the LSTM or non-reccurrent architecture
     use_lstm: bool = True

--- a/libraries/mathy_python/mathy/agents/densenet.py
+++ b/libraries/mathy_python/mathy/agents/densenet.py
@@ -1,0 +1,120 @@
+from typing import List, Optional
+
+import tensorflow as tf
+
+
+class DenseNetBlock(tf.keras.layers.Layer):
+    """DenseNet like block layer that concatenates inputs with extracted features
+    and feeds them into all future tower layers."""
+
+    def __init__(
+        self,
+        units=128,
+        num_layers=2,
+        use_shared=False,
+        activation="relu",
+        normalization="batch",
+        **kwargs,
+    ):
+        super(DenseNetBlock, self).__init__(**kwargs)
+        self.use_shared = use_shared
+        self.activate = tf.keras.layers.Activation("relu", name="relu")
+        if normalization == "batch":
+            self.normalize = tf.keras.layers.BatchNormalization()
+        elif normalization == "layer":
+            self.normalize = tf.keras.layers.LayerNormalization()
+        else:
+            raise ValueError(f"unkknown layer normalization style: {normalization}")
+        self.dense = tf.keras.layers.Dense(
+            units, use_bias=False, name=f"{self.name}_dense"
+        )
+        self.concat = tf.keras.layers.Concatenate(name=f"{self.name}_concat")
+        self.activate = tf.keras.layers.Activation(activation, name="activate")
+
+    def do_op(self, input_tensor: tf.Tensor, previous_tensors: List[tf.Tensor]):
+        inputs = previous_tensors[:]
+        inputs.append(input_tensor)
+        # concatenate the input and previous layer inputs
+        if (len(inputs)) > 1:
+            input_tensor = self.concat(inputs)
+        return self.normalize(self.activate(self.dense(input_tensor)))
+
+    def call(self, input_tensor: tf.Tensor, previous_tensors: List[tf.Tensor]):
+        if self.use_shared:
+            with tf.compat.v1.variable_scope(
+                self.name, reuse=True, auxiliary_name_scope=False
+            ):
+                return self.do_op(input_tensor, previous_tensors)
+        else:
+            with tf.compat.v1.variable_scope(self.name):
+                return self.do_op(input_tensor, previous_tensors)
+
+
+class DenseNetStack(tf.keras.layers.Layer):
+    """DenseNet like stack of residually connected layers where the input and all
+    of the previous outputs are provided as the input to each layer:
+
+        https://arxiv.org/pdf/1608.06993.pdf
+
+    From the paper: "Crucially, in contrast to ResNets, we never combine features
+    through summation before they are passed into a layer; instead, we combine features
+    by concatenating them"
+    """
+
+    def __init__(
+        self,
+        units=64,
+        num_layers=4,
+        layer_scaling_factor=0.75,
+        share_weights=False,
+        activation="relu",
+        output_transform: Optional[tf.keras.layers.Layer] = None,
+        normalization_style: str = "layer",
+        **kwargs,
+    ):
+        self.units = units
+        self.layer_scaling_factor = layer_scaling_factor
+        self.num_layers = num_layers
+        self.output_transform = output_transform
+        if activation is not None:
+            self.activate = tf.keras.layers.Activation(activation)
+        else:
+            self.activate = None
+        self.concat = tf.keras.layers.Concatenate()
+        block_units = int(self.units)
+        self.dense_stack = [
+            DenseNetBlock(
+                block_units,
+                name="densenet_0",
+                use_shared=share_weights,
+                normalization=normalization_style,
+            )
+        ]
+        for i in range(self.num_layers - 1):
+            block_units = int(block_units * self.layer_scaling_factor)
+            self.dense_stack.append(
+                DenseNetBlock(
+                    block_units,
+                    name=f"densenet_{i + 1}",
+                    use_shared=share_weights,
+                    normalization=normalization_style,
+                )
+            )
+        super(DenseNetStack, self).__init__(**kwargs)
+
+    def call(self, input_tensor: tf.Tensor):
+        stack_inputs: List[tf.Tensor] = []
+        root_input = input_tensor
+        # Iterate the stack and call each layer, also inputting a list
+        # of all the previous stack layers outputs.
+        for layer in self.dense_stack:
+            # Save reference to input
+            prev_tensor = input_tensor
+            # Apply densnet block
+            input_tensor = layer(input_tensor, stack_inputs)
+            # Append the current input to the list of previous input tensors
+            stack_inputs.append(prev_tensor)
+        output = self.concat([input_tensor, root_input])
+        if self.output_transform is not None:
+            output = self.output_transform(output)
+        return self.activate(output) if self.activate is not None else output

--- a/libraries/mathy_python/mathy/agents/densenet.py
+++ b/libraries/mathy_python/mathy/agents/densenet.py
@@ -17,6 +17,7 @@ class DenseNetBlock(tf.keras.layers.Layer):
         **kwargs,
     ):
         super(DenseNetBlock, self).__init__(**kwargs)
+        self.units = units
         self.use_shared = use_shared
         self.activate = tf.keras.layers.Activation("relu", name="relu")
         if normalization == "batch":

--- a/libraries/mathy_python/mathy/agents/mcts.py
+++ b/libraries/mathy_python/mathy/agents/mcts.py
@@ -18,11 +18,11 @@ class MCTS:
     env: MathyEnv
     # cpuct is a hyperparameter controlling the degree of exploration
     # (1.0 in Suragnair experiments.)
-    cpuct: int
+    cpuct: float
     num_mcts_sims: int
     # Set epsilon = 0 to disable dirichlet noise in root node.
     # e.g. for ExaminationRunner competitions
-    epsilon: int
+    epsilon: float
     dir_alpha: float
 
     def __init__(
@@ -128,7 +128,7 @@ class MCTS:
                 rnn_history_h=rnn_state[0],
             )
             observations = observations_to_window([obs]).to_inputs()
-            out_policy, state_v = self.model.predict_next(observations)
+            out_policy, state_v = self.model.predict_next(observations, use_graph=False)
             out_rnn_state = [
                 tf.squeeze(self.model.embedding.state_h).numpy(),
                 tf.squeeze(self.model.embedding.state_c).numpy(),

--- a/libraries/mathy_python/mathy/agents/policy_value_model.py
+++ b/libraries/mathy_python/mathy/agents/policy_value_model.py
@@ -92,11 +92,7 @@ class PolicyValueModel(tf.keras.Model):
         mask_logits = self.apply_pi_mask(logits, features_window)
         mask_result = logits if not apply_mask else mask_logits
         if call_print is True:
-            print(
-                "call took : {0:03f} for batch of {1:03}".format(
-                    time.time() - start, batch_size
-                )
-            )
+            print("call took : {0:03f}".format(time.time() - start))
         return logits, values, mask_result
 
     def apply_pi_mask(
@@ -126,10 +122,15 @@ class PolicyValueModel(tf.keras.Model):
         """Autograph optimized function"""
         return self.call(inputs)
 
-    def predict_next(self, inputs: MathyInputsType) -> Tuple[tf.Tensor, tf.Tensor]:
+    def predict_next(
+        self, inputs: MathyInputsType, use_graph=False
+    ) -> Tuple[tf.Tensor, tf.Tensor]:
         """Predict one probability distribution and value for the
-        given sequence of inputs"""
-        logits, values, masked = self.call(inputs)
+        given sequence of inputs """
+        if use_graph:
+            logits, values, masked = self.call_graph(inputs)
+        else:
+            logits, values, masked = self.call(inputs)
         # take the last timestep
         masked = masked[-1][:]
         flat_logits = tf.reshape(tf.squeeze(masked), [-1])

--- a/libraries/mathy_python/mathy/agents/zero/config.py
+++ b/libraries/mathy_python/mathy/agents/zero/config.py
@@ -8,8 +8,7 @@ class SelfPlayConfig(BaseConfig):
     temperature_threshold: float = 0.5
     self_play_problems: int = 64
     training_iterations: int = 100
-    cpuct: float = 1.0
-
-
+    cpuct: float = 1.0 
+    normalization_style: str = "batch"
     # When profile is true and workers == 1 the main thread will output worker_0.profile on exit
     profile: bool = False

--- a/libraries/mathy_python/mathy/agents/zero/config.py
+++ b/libraries/mathy_python/mathy/agents/zero/config.py
@@ -9,3 +9,7 @@ class SelfPlayConfig(BaseConfig):
     self_play_problems: int = 64
     training_iterations: int = 100
     cpuct: float = 1.0
+
+
+    # When profile is true and workers == 1 the main thread will output worker_0.profile on exit
+    profile: bool = False

--- a/libraries/mathy_python/mathy/agents/zero/config.py
+++ b/libraries/mathy_python/mathy/agents/zero/config.py
@@ -8,7 +8,11 @@ class SelfPlayConfig(BaseConfig):
     temperature_threshold: float = 0.5
     self_play_problems: int = 64
     training_iterations: int = 100
-    cpuct: float = 1.0 
+    cpuct: float = 1.0
     normalization_style: str = "batch"
     # When profile is true and workers == 1 the main thread will output worker_0.profile on exit
     profile: bool = False
+    # Don't use the LSTM with Zero agents because the random sampling breaks
+    # timestep correlations across the batch.
+    use_lstm: bool = False
+

--- a/libraries/mathy_python/mathy/agents/zero/practice_runner.py
+++ b/libraries/mathy_python/mathy/agents/zero/practice_runner.py
@@ -323,7 +323,7 @@ class ParallelPracticeRunner(PracticeRunner):
         for i, args in enumerate(episode_args_list):
             work_queue.put((i, args))
         processes = [
-            Process(target=worker, args=(i, work_queue, result_queue))
+            Process(target=worker, args=(i, work_queue, result_queue), daemon=True)
             for i in range(self.config.num_workers)
         ]
         for proc in processes:

--- a/libraries/mathy_python/mathy/agents/zero/practice_runner.py
+++ b/libraries/mathy_python/mathy/agents/zero/practice_runner.py
@@ -160,7 +160,7 @@ class PracticeRunner:
                     problem,
                 ) = self.execute_episode(i, game, predictor, **args)
                 duration = time.time() - start
-                examples.append(episode_examples)
+                examples.extend(episode_examples)
                 episode_summary = EpisodeSummary(
                     solved=bool(is_win),
                     text=problem.text,
@@ -310,7 +310,7 @@ class ParallelPracticeRunner(PracticeRunner):
                 self.episode_complete(i, summary)
                 count += 1
                 if "error" not in summary:
-                    examples.append(episode_examples)
+                    examples.extend(episode_examples)
                     results.append(summary)
             except queue.Empty:
                 pass

--- a/libraries/mathy_python/mathy/agents/zero/practice_runner.py
+++ b/libraries/mathy_python/mathy/agents/zero/practice_runner.py
@@ -41,10 +41,10 @@ class PracticeRunner:
             )
         self.config = config
 
-    def get_game(self):
+    def get_env(self):
         raise NotImplementedError("game implementation must be provided by subclass")
 
-    def get_predictor(self, game):
+    def get_model(self, game):
         raise NotImplementedError(
             "predictor implementation must be provided by subclass"
         )
@@ -155,8 +155,8 @@ class PracticeRunner:
             pr.enable()
 
         try:
-            game = self.get_game()
-            predictor = self.get_predictor(game)
+            game = self.get_env()
+            predictor = self.get_model(game)
             for i, args in enumerate(episode_args_list):
                 start = time.time()
                 (
@@ -204,9 +204,9 @@ class PracticeRunner:
         in trainExamples.
         """
         if game is None:
-            raise NotImplementedError("PracticeRunner.get_game returned None type")
+            raise ValueError("PracticeRunner.get_env returned None type")
         if predictor is None:
-            raise NotImplementedError("PracticeRunner.get_predictor returned None type")
+            raise ValueError("PracticeRunner.get_model returned None type")
         game.reset()
         if game.state is None:
             raise ValueError("Cannot start self-play practice with a None game state.")
@@ -259,8 +259,8 @@ class PracticeRunner:
         )
 
     def train_with_examples(self, iteration, train_examples, model_path=None):
-        game = self.get_game()
-        new_net = self.get_predictor(game)
+        game = self.get_env()
+        new_net = self.get_model(game)
         trainer = SelfPlayTrainer(self.config, new_net, action_size=new_net.predictions)
         if trainer.train(train_examples, new_net):
             new_net.save()
@@ -277,8 +277,8 @@ class ParallelPracticeRunner(PracticeRunner):
         def worker(worker_idx: int, work_queue: Queue, result_queue: Queue):
             """Pull items out of the work queue and execute episodes until there are
             no items left """
-            game = self.get_game()
-            predictor = self.get_predictor(game)
+            game = self.get_env()
+            predictor = self.get_model(game)
             msg.good(f"Worker {worker_idx} started.")
 
             while (

--- a/libraries/mathy_python/mathy/agents/zero/practice_session.py
+++ b/libraries/mathy_python/mathy/agents/zero/practice_session.py
@@ -79,7 +79,7 @@ class PracticeSession:
             bar.next()
 
         episodes_with_args = []
-        for _ in range(1, num_episodes + 1):
+        for i in range(1, num_episodes + 1):
             episodes_with_args.append(dict(model_dir=self.runner.config.model_dir))
 
         old_update = self.runner.episode_complete

--- a/libraries/mathy_python/mathy/agents/zero/self_play_runner.py
+++ b/libraries/mathy_python/mathy/agents/zero/self_play_runner.py
@@ -27,12 +27,12 @@ def self_play_runner(config: SelfPlayConfig):
         print(config.json(indent=2))
 
     class LessonRunner(BaseEpisodeRunner):  # type:ignore
-        def get_game(self):
+        def get_env(self):
             import gym
 
             return gym.make(lesson_name)
 
-        def get_predictor(self, game):
+        def get_model(self, game):
             from ...agents.policy_value_model import (
                 get_or_create_policy_model,
                 PolicyValueModel,

--- a/libraries/mathy_python/mathy/agents/zero/self_play_runner.py
+++ b/libraries/mathy_python/mathy/agents/zero/self_play_runner.py
@@ -20,6 +20,8 @@ def self_play_runner(config: SelfPlayConfig):
     BaseEpisodeRunner = (
         PracticeRunner if config.num_workers < 2 else ParallelPracticeRunner
     )
+    if config.profile and config.num_workers > 1:
+        raise NotImplementedError("zero agent does not support multiprocess profiling")
     lesson_name = "mathy-poly-easy-v0"
     if config.verbose:
         print(config.json(indent=2))

--- a/libraries/mathy_python/mathy/agents/zero/self_play_runner.py
+++ b/libraries/mathy_python/mathy/agents/zero/self_play_runner.py
@@ -39,7 +39,7 @@ def self_play_runner(config: SelfPlayConfig):
             )
 
             model: PolicyValueModel = get_or_create_policy_model(
-                args=config, env_actions=game.action_space.n,
+                args=config, env_actions=game.action_space.n, is_main=True
             )
             return model
 

--- a/libraries/mathy_python/mathy/cli.py
+++ b/libraries/mathy_python/mathy/cli.py
@@ -135,7 +135,7 @@ def cli_print_problems(environment: str, difficulty: str, number: int):
 @click.option(
     "units",
     "--units",
-    default=512,
+    default=256,
     type=int,
     help="Number of dimensions to use for math vectors and model dimensions",
 )
@@ -145,6 +145,13 @@ def cli_print_problems(environment: str, difficulty: str, number: int):
     default=512,
     type=int,
     help="Number of dimensions to use for token embeddings",
+)
+@click.option(
+    "use_lstm",
+    "--use-lstm",
+    default=True,
+    type=bool,
+    help="Whether to use the recurrent architecture or not",
 )
 @click.option(
     "rnn",
@@ -218,6 +225,7 @@ def cli_train(
     verbose: bool,
     training_iterations: int,
     self_play_problems: int,
+    use_lstm: bool,
 ):
     """Train an agent to solve math problems and save the model.
 
@@ -252,6 +260,7 @@ def cli_train(
             num_workers=workers,
             profile=profile,
             print_training=show,
+            use_lstm=use_lstm,
         )
         if episodes is not None:
             args.max_eps = episodes
@@ -276,6 +285,7 @@ def cli_train(
             self_play_problems=self_play_problems,
             print_training=show,
             profile=profile,
+            use_lstm=use_lstm,
         )
         if episodes is not None:
             self_play_cfg.max_eps = episodes

--- a/libraries/mathy_python/mathy/cli.py
+++ b/libraries/mathy_python/mathy/cli.py
@@ -258,7 +258,7 @@ def cli_train(
         instance = A3CAgent(args)
         instance.train()
     elif agent == "zero":
-        setup_tf_env(use_mp=True)
+        setup_tf_env(use_mp=workers > 1)
         from .agents.zero import SelfPlayConfig, self_play_runner
 
         self_play_cfg = SelfPlayConfig(
@@ -275,6 +275,7 @@ def cli_train(
             training_iterations=training_iterations,
             self_play_problems=self_play_problems,
             print_training=show,
+            profile=profile,
         )
         if episodes is not None:
             self_play_cfg.max_eps = episodes

--- a/libraries/mathy_python/mathy/cli.py
+++ b/libraries/mathy_python/mathy/cli.py
@@ -135,7 +135,7 @@ def cli_print_problems(environment: str, difficulty: str, number: int):
 @click.option(
     "units",
     "--units",
-    default=256,
+    default=512,
     type=int,
     help="Number of dimensions to use for math vectors and model dimensions",
 )

--- a/libraries/mathy_python/mathy/envs/binomial_distribute.py
+++ b/libraries/mathy_python/mathy/envs/binomial_distribute.py
@@ -1,20 +1,25 @@
 from typing import Any, List, Optional, Type
 
-from .. import time_step
+from numpy.random import randint, uniform
 
-from ..core.rule import BaseRule
+from .. import time_step
 from ..core.expressions import MathExpression
-from ..util import get_terms, has_like_terms, is_preferred_term_form
+from ..core.rule import BaseRule
 from ..env import MathyEnv, MathyEnvProblem
-from ..problems import gen_binomial_times_binomial, gen_binomial_times_monomial, rand_bool
+from ..problems import (
+    gen_binomial_times_binomial,
+    gen_binomial_times_monomial,
+    rand_bool,
+)
 from ..rules import (
-    ConstantsSimplifyRule,
     CommutativeSwapRule,
+    ConstantsSimplifyRule,
     DistributiveMultiplyRule,
     VariableMultiplyRule,
 )
 from ..state import MathyEnvState, MathyObservation
 from ..types import MathyEnvDifficulty, MathyEnvProblemArgs
+from ..util import get_terms, has_like_terms, is_preferred_term_form
 
 
 class BinomialDistribute(MathyEnv):
@@ -59,23 +64,23 @@ class BinomialDistribute(MathyEnv):
                 text, complexity = gen_binomial_times_binomial(
                     min_vars=2,
                     max_vars=3,
-                    powers_probability=0.1,
-                    like_variables_probability=0.5,
+                    powers_probability=uniform(0.1, 0.4),
+                    like_variables_probability=uniform(0.3, 0.7),
                 )
         elif params.difficulty == MathyEnvDifficulty.normal:
             text, complexity = gen_binomial_times_binomial(
                 min_vars=2,
                 max_vars=2,
-                powers_probability=0.4,
-                like_variables_probability=0.2,
+                powers_probability=uniform(0.2, 0.6),
+                like_variables_probability=uniform(0.2, 0.5),
             )
         elif params.difficulty == MathyEnvDifficulty.hard:
             text, complexity = gen_binomial_times_binomial(
                 min_vars=2,
                 max_vars=3,
                 simple_variables=False,
-                powers_probability=0.8,
-                like_variables_probability=0.8,
+                powers_probability=uniform(0.4, 0.8),
+                like_variables_probability=uniform(0.1, 0.3),
             )
             complexity += 2
         else:

--- a/libraries/mathy_python/mathy/envs/complex_simplify.py
+++ b/libraries/mathy_python/mathy/envs/complex_simplify.py
@@ -44,8 +44,8 @@ class ComplexSimplify(PolySimplify):
                 op="*",
                 optional_var=True,
                 inner_terms_scaling=scaling,
-                powers_probability=0.4,
-                noise_probability=0.2,
+                powers_probability=uniform(0.2, 0.5),
+                noise_probability=uniform(0.2, 0.5),
             )
         elif params.difficulty == MathyEnvDifficulty.normal:
             num_terms = randint(3, 6)
@@ -55,7 +55,7 @@ class ComplexSimplify(PolySimplify):
                 op="*",
                 optional_var=True,
                 inner_terms_scaling=scaling,
-                powers_probability=0.6,
+                powers_probability=uniform(0.4, 0.7),
             )
         elif params.difficulty == MathyEnvDifficulty.hard:
             num_terms = randint(4, 8)
@@ -63,8 +63,8 @@ class ComplexSimplify(PolySimplify):
             text, complexity = gen_simplify_multiple_terms(
                 num_terms,
                 op="*",
-                shuffle_probability=0.5,
-                powers_probability=0.8,
+                shuffle_probability=uniform(0.3, 0.8),
+                powers_probability=uniform(0.4, 0.9),
                 inner_terms_scaling=scaling,
             )
         else:

--- a/libraries/mathy_python/tests/test_densenet.py
+++ b/libraries/mathy_python/tests/test_densenet.py
@@ -1,0 +1,56 @@
+import pytest
+import numpy as np
+from ..mathy.agents.densenet import DenseNetBlock, DenseNetStack
+import tensorflow as tf
+
+
+def test_densenet_construction():
+    layer: DenseNetStack = DenseNetStack()
+    assert layer is not None
+    model = tf.keras.Sequential([layer])
+    model(np.zeros(shape=(128, 1)))
+
+
+def test_densenet_errors():
+    with pytest.raises(ValueError):
+        DenseNetStack(normalization_style="invalid")
+
+
+@pytest.mark.parametrize("norm_type", ("batch", "layer"))
+def test_densenet_normalization_types(norm_type: str):
+    model = tf.keras.Sequential(
+        [DenseNetStack(units=24, num_layers=4, normalization_style=norm_type)]
+    )
+    y = model(np.zeros(shape=(10, 1)))
+
+
+def test_densenet_no_activation():
+    model = tf.keras.Sequential(
+        [DenseNetStack(units=24, num_layers=4, activation=None)]
+    )
+    y = model(np.zeros(shape=(10, 1)))
+    assert y.shape[0] == 10
+
+
+def test_densenet_output_transform():
+    layer: DenseNetStack = DenseNetStack(
+        units=10,
+        num_layers=4,
+        activation=None,
+        output_transform=tf.keras.layers.Dense(128),
+    )
+    assert layer is not None
+    model = tf.keras.Sequential([layer])
+    x = np.zeros(shape=(10, 1))
+    y = model(x)
+    assert y.shape[1] == 128
+
+
+def test_densenet_share_weights():
+    layer: DenseNetStack = DenseNetStack(share_weights=True)
+    layer_two: DenseNetStack = DenseNetStack(share_weights=True)
+    assert layer.get_weights() == layer_two.get_weights()
+    model = tf.keras.Sequential([layer, layer_two])
+    x = np.zeros(shape=(10, 1))
+    y = model(x)
+

--- a/libraries/mathy_python/tests/test_envs.py
+++ b/libraries/mathy_python/tests/test_envs.py
@@ -12,6 +12,8 @@ def test_mathy_env_init():
     # Default env is abstract and cannot be directly used for problem solving
     with pytest.raises(NotImplementedError):
         env.get_initial_state()
+    with pytest.raises(NotImplementedError):
+        env.get_env_namespace()
 
 
 def test_env_terminal_conditions():
@@ -62,7 +64,7 @@ def test_env_finalize_state():
     )
     with pytest.raises(ValueError):
         env.finalize_state(env_state)
-        
+
     env_state = MathyEnvState(problem="4x + 2x").get_out_state(
         problem="4x + 2y", action=1, focus_index=-1, moves_remaining=0
     )

--- a/libraries/mathy_python/tests/test_self_play.py
+++ b/libraries/mathy_python/tests/test_self_play.py
@@ -1,0 +1,12 @@
+import pytest
+
+from ..mathy.agents.zero import SelfPlayConfig, self_play_runner
+
+
+def test_self_play_runner_errors():
+    """Throws error for bad profiling configuration of zero agent.
+    
+    This is only because it wasn't clear how to profile multiple processes that
+    stop/start overtime during training/evaluation loops"""
+    with pytest.raises(NotImplementedError):
+        self_play_runner(SelfPlayConfig(profile=True, num_workers=2))

--- a/libraries/mathy_python/tests/test_zero.py
+++ b/libraries/mathy_python/tests/test_zero.py
@@ -1,10 +1,12 @@
-from typing import List, Tuple
+from typing import Any, List, Tuple
 
 import pytest
+from pydantic import BaseModel
 
 from ..mathy import envs
 from ..mathy.agents.policy_value_model import PolicyValueModel
 from ..mathy.agents.zero.config import SelfPlayConfig
+from ..mathy.agents.zero.practice_runner import PracticeRunner
 from ..mathy.agents.zero.trainer import SelfPlayTrainer
 from ..mathy.env import MathyEnv
 from ..mathy.state import MathyObservation, observations_to_window
@@ -16,3 +18,33 @@ def test_mathy_zero_trainer_constructor():
     model = PolicyValueModel(config, predictions=env.action_size)
     with pytest.raises(NotImplementedError):
         SelfPlayTrainer(config, model, env.action_size)
+
+
+def test_mathy_zero_practice_runner():
+    with pytest.raises(ValueError):
+        # Must be SelfPlayConfig or a subclass
+        PracticeRunner(BaseModel())
+
+    runner = PracticeRunner(SelfPlayConfig())
+    with pytest.raises(NotImplementedError):
+        runner.get_env()
+    with pytest.raises(NotImplementedError):
+        runner.get_model(None)
+
+
+def test_mathy_zero_practice_runner_execute_episode():
+    runner = PracticeRunner(SelfPlayConfig())
+
+    class FakeEnv:
+        def __init__(self):
+            self.state = None
+
+        def reset(self):
+            pass
+
+    with pytest.raises(ValueError):
+        runner.execute_episode(1, None, None, "", False)
+    with pytest.raises(ValueError):
+        runner.execute_episode(1, FakeEnv(), None, "", False)
+    with pytest.raises(ValueError):
+        runner.execute_episode(1, FakeEnv(), FakeEnv(), "", False)

--- a/libraries/website/docs/ml/a3c.md
+++ b/libraries/website/docs/ml/a3c.md
@@ -93,29 +93,7 @@ The CLI A3C agent accepts a `--profile` option, or a config option when the API 
 {!./snippets/ml/a3c_profiling.py!}
 ```
 
-The output files can be visualized using **[Snakeviz](https://jiffyclub.github.io/snakeviz/){target=\_blank}**:
-
-You can install Snakeviz if it's not already present:
-
-```bash
-pip install snakeviz
-```
-
-You can view the output from the previous run:
-
-```bash
-snakeviz /the_folder_my_model_is_in/worker_0.profile
-```
-
-Running the above command will launch a webpage on your local system.
-
-The webpage has performance information about the training run that just finished.
-
-Clicking on the various functions will expand them further.
-
-You can use this "drilling in" to find spots of code that may be using lots of time when they should not be.
-
-<img mathy-logo src="/img/snakeviz_profile.png" alt="View agent performance profile in Skakeviz">
+Learn about how to view output profiles on the [debugging page](/ml/debugging)
 
 ## Multiprocess A3C
 

--- a/libraries/website/docs/ml/a3c.md
+++ b/libraries/website/docs/ml/a3c.md
@@ -93,7 +93,7 @@ The CLI A3C agent accepts a `--profile` option, or a config option when the API 
 {!./snippets/ml/a3c_profiling.py!}
 ```
 
-Learn about how to view output profiles on the [debugging page](/ml/debugging)
+Learn about how to view output profiles on the [debugging page](/ml/debugging/#snakeviz)
 
 ## Multiprocess A3C
 

--- a/libraries/website/docs/ml/zero.md
+++ b/libraries/website/docs/ml/zero.md
@@ -27,3 +27,18 @@ In this mode you can set breakpoints in the debugger to help diagnose errors.
 ```python
 {!./snippets/ml/zero_debugging.py!}
 ```
+
+### Performance Profiling
+
+The CLI Zero agent accepts `--profile` option along with `--num-workers=1` or the same config options when the API is used.
+
+!!! warning "Limited to num_workers=1"
+
+    It wasn't immediately clear how to profile multiple processes that start and stop over time, so to profile zero you must
+    specify a single worker process.
+
+```python
+{!./snippets/ml/a3c_profiling.py!}
+```
+
+Learn about how to view output profiles on the [debugging page](/ml/debugging)

--- a/libraries/website/docs/ml/zero.md
+++ b/libraries/website/docs/ml/zero.md
@@ -28,17 +28,16 @@ In this mode you can set breakpoints in the debugger to help diagnose errors.
 {!./snippets/ml/zero_debugging.py!}
 ```
 
-### Performance Profiling
+## Performance Profiling
 
-The CLI Zero agent accepts `--profile` option along with `--num-workers=1` or the same config options when the API is used.
+The CLI Zero agent can optionally output performance profiles.
 
-!!! warning "Limited to num_workers=1"
+For the CLI you do this with `--profile --num-workers=1`.
 
-    It wasn't immediately clear how to profile multiple processes that start and stop over time, so to profile zero you must
-    specify a single worker process.
+In python you pass `profile=True` and `num_workers=1` to the agent configuration.
 
 ```python
-{!./snippets/ml/a3c_profiling.py!}
+{!./snippets/ml/zero_profiling.py!}
 ```
 
-Learn about how to view output profiles on the [debugging page](/ml/debugging)
+Learn about how to view output profiles on the [debugging page](/ml/debugging/#snakeviz)

--- a/libraries/website/docs/snippets/cas/overview/evaluate_expression.ipynb
+++ b/libraries/website/docs/snippets/cas/overview/evaluate_expression.ipynb
@@ -8,8 +8,8 @@
    },
    "outputs": [],
    "source": [
-    "# This file is generated from a mathy documentation code snippet.\n",
-    "!pip install mathy\n",
+    "# This file is generated from a Mathy (https://mathy.ai) code example.\n",
+    "!pip install mathy --upgrade\n",
     "from mathy import ExpressionParser\n",
     "\n",
     "expression = ExpressionParser().parse(\"4 + 2\")\n",

--- a/libraries/website/docs/snippets/cas/overview/evaluate_expression_variables.ipynb
+++ b/libraries/website/docs/snippets/cas/overview/evaluate_expression_variables.ipynb
@@ -8,8 +8,8 @@
    },
    "outputs": [],
    "source": [
-    "# This file is generated from a mathy documentation code snippet.\n",
-    "!pip install mathy\n",
+    "# This file is generated from a Mathy (https://mathy.ai) code example.\n",
+    "!pip install mathy --upgrade\n",
     "from mathy import ExpressionParser, MathExpression\n",
     "\n",
     "expression: MathExpression = ExpressionParser().parse(\"4x + 2y\")\n",

--- a/libraries/website/docs/snippets/cas/overview/rules_factor_out.ipynb
+++ b/libraries/website/docs/snippets/cas/overview/rules_factor_out.ipynb
@@ -8,8 +8,8 @@
    },
    "outputs": [],
    "source": [
-    "# This file is generated from a mathy documentation code snippet.\n",
-    "!pip install mathy\n",
+    "# This file is generated from a Mathy (https://mathy.ai) code example.\n",
+    "!pip install mathy --upgrade\n",
     "from mathy import DistributiveFactorOutRule, ExpressionParser\n",
     "\n",
     "input = \"4x + 2x\"\n",

--- a/libraries/website/docs/snippets/cas/tokenizer_manual.ipynb
+++ b/libraries/website/docs/snippets/cas/tokenizer_manual.ipynb
@@ -8,8 +8,8 @@
    },
    "outputs": [],
    "source": [
-    "# This file is generated from a mathy documentation code snippet.\n",
-    "!pip install mathy\n",
+    "# This file is generated from a Mathy (https://mathy.ai) code example.\n",
+    "!pip install mathy --upgrade\n",
     "from typing import List\n",
     "from mathy import Token, TokenConstant, TokenEOF, Tokenizer, TokenPlus, TokenVariable\n",
     "\n",

--- a/libraries/website/docs/snippets/cas/tokenizer_tokenize.ipynb
+++ b/libraries/website/docs/snippets/cas/tokenizer_tokenize.ipynb
@@ -8,8 +8,8 @@
    },
    "outputs": [],
    "source": [
-    "# This file is generated from a mathy documentation code snippet.\n",
-    "!pip install mathy\n",
+    "# This file is generated from a Mathy (https://mathy.ai) code example.\n",
+    "!pip install mathy --upgrade\n",
     "from typing import List\n",
     "from mathy import Tokenizer, Token\n",
     "\n",

--- a/libraries/website/docs/snippets/create_a_rule.ipynb
+++ b/libraries/website/docs/snippets/create_a_rule.ipynb
@@ -8,8 +8,8 @@
    },
    "outputs": [],
    "source": [
-    "# This file is generated from a mathy documentation code snippet.\n",
-    "!pip install mathy\n",
+    "# This file is generated from a Mathy (https://mathy.ai) code example.\n",
+    "!pip install mathy --upgrade\n",
     "from mathy import (\n",
     "    AddExpression,\n",
     "    ExpressionParser,\n",

--- a/libraries/website/docs/snippets/envs/custom_actions.ipynb
+++ b/libraries/website/docs/snippets/envs/custom_actions.ipynb
@@ -8,8 +8,8 @@
    },
    "outputs": [],
    "source": [
-    "# This file is generated from a mathy documentation code snippet.\n",
-    "!pip install mathy\n",
+    "# This file is generated from a Mathy (https://mathy.ai) code example.\n",
+    "!pip install mathy --upgrade\n",
     "\"\"\"Environment with user-defined actions\"\"\"\n",
     "\n",
     "from mathy import (\n",

--- a/libraries/website/docs/snippets/envs/custom_episode_rewards.ipynb
+++ b/libraries/website/docs/snippets/envs/custom_episode_rewards.ipynb
@@ -8,8 +8,8 @@
    },
    "outputs": [],
    "source": [
-    "# This file is generated from a mathy documentation code snippet.\n",
-    "!pip install mathy\n",
+    "# This file is generated from a Mathy (https://mathy.ai) code example.\n",
+    "!pip install mathy --upgrade\n",
     "\"\"\"Environment with user-defined terminal rewards\"\"\"\n",
     "\n",
     "from mathy import MathyEnvState, envs, is_terminal_transition\n",

--- a/libraries/website/docs/snippets/envs/custom_problem_text.ipynb
+++ b/libraries/website/docs/snippets/envs/custom_problem_text.ipynb
@@ -8,8 +8,8 @@
    },
    "outputs": [],
    "source": [
-    "# This file is generated from a mathy documentation code snippet.\n",
-    "!pip install mathy\n",
+    "# This file is generated from a Mathy (https://mathy.ai) code example.\n",
+    "!pip install mathy --upgrade\n",
     "from mathy import MathyEnv, MathyEnvProblem, MathyEnvProblemArgs\n",
     "\n",
     "\n",

--- a/libraries/website/docs/snippets/envs/custom_timestep_rewards.ipynb
+++ b/libraries/website/docs/snippets/envs/custom_timestep_rewards.ipynb
@@ -8,8 +8,8 @@
    },
    "outputs": [],
    "source": [
-    "# This file is generated from a mathy documentation code snippet.\n",
-    "!pip install mathy\n",
+    "# This file is generated from a Mathy (https://mathy.ai) code example.\n",
+    "!pip install mathy --upgrade\n",
     "\"\"\"Environment with user-defined rewards per-timestep based on the\n",
     "rule that was applied by the agent.\"\"\"\n",
     "\n",

--- a/libraries/website/docs/snippets/envs/custom_win_conditions.ipynb
+++ b/libraries/website/docs/snippets/envs/custom_win_conditions.ipynb
@@ -8,8 +8,8 @@
    },
    "outputs": [],
    "source": [
-    "# This file is generated from a mathy documentation code snippet.\n",
-    "!pip install mathy\n",
+    "# This file is generated from a Mathy (https://mathy.ai) code example.\n",
+    "!pip install mathy --upgrade\n",
     "\"\"\"Custom environment with win conditions that are met whenever\n",
     "two nodes are adjacent to each other that can have the distributive\n",
     "property applied to factor out a common term \"\"\"\n",

--- a/libraries/website/docs/snippets/envs/openai_gym.ipynb
+++ b/libraries/website/docs/snippets/envs/openai_gym.ipynb
@@ -8,8 +8,8 @@
    },
    "outputs": [],
    "source": [
-    "# This file is generated from a mathy documentation code snippet.\n",
-    "!pip install mathy\n",
+    "# This file is generated from a Mathy (https://mathy.ai) code example.\n",
+    "!pip install mathy --upgrade\n",
     "!pip install gym\n",
     "import gym\n",
     "import mathy.envs.gym\n",

--- a/libraries/website/docs/snippets/ml/a3c_profiling.ipynb
+++ b/libraries/website/docs/snippets/ml/a3c_profiling.ipynb
@@ -8,8 +8,8 @@
    },
    "outputs": [],
    "source": [
-    "# This file is generated from a mathy documentation code snippet.\n",
-    "!pip install mathy\n",
+    "# This file is generated from a Mathy (https://mathy.ai) code example.\n",
+    "!pip install mathy --upgrade\n",
     "!pip install gym\n",
     "import os\n",
     "from mathy.cli import setup_tf_env\n",

--- a/libraries/website/docs/snippets/ml/a3c_training.ipynb
+++ b/libraries/website/docs/snippets/ml/a3c_training.ipynb
@@ -8,8 +8,8 @@
    },
    "outputs": [],
    "source": [
-    "# This file is generated from a mathy documentation code snippet.\n",
-    "!pip install mathy\n",
+    "# This file is generated from a Mathy (https://mathy.ai) code example.\n",
+    "!pip install mathy --upgrade\n",
     "!pip install gym\n",
     "from mathy.cli import setup_tf_env\n",
     "from mathy.agents.a3c import A3CAgent, A3CConfig\n",

--- a/libraries/website/docs/snippets/ml/a3c_training_mcts_worker_0.ipynb
+++ b/libraries/website/docs/snippets/ml/a3c_training_mcts_worker_0.ipynb
@@ -8,8 +8,8 @@
    },
    "outputs": [],
    "source": [
-    "# This file is generated from a mathy documentation code snippet.\n",
-    "!pip install mathy\n",
+    "# This file is generated from a Mathy (https://mathy.ai) code example.\n",
+    "!pip install mathy --upgrade\n",
     "!pip install gym\n",
     "from mathy.cli import setup_tf_env\n",
     "from mathy.agents.a3c import A3CAgent, A3CConfig\n",

--- a/libraries/website/docs/snippets/ml/a3c_training_mcts_worker_n.ipynb
+++ b/libraries/website/docs/snippets/ml/a3c_training_mcts_worker_n.ipynb
@@ -8,8 +8,8 @@
    },
    "outputs": [],
    "source": [
-    "# This file is generated from a mathy documentation code snippet.\n",
-    "!pip install mathy\n",
+    "# This file is generated from a Mathy (https://mathy.ai) code example.\n",
+    "!pip install mathy --upgrade\n",
     "!pip install gym\n",
     "from mathy.cli import setup_tf_env\n",
     "from mathy.agents.a3c import A3CAgent, A3CConfig\n",

--- a/libraries/website/docs/snippets/ml/embeddings_inference.ipynb
+++ b/libraries/website/docs/snippets/ml/embeddings_inference.ipynb
@@ -8,8 +8,8 @@
    },
    "outputs": [],
    "source": [
-    "# This file is generated from a mathy documentation code snippet.\n",
-    "!pip install mathy\n",
+    "# This file is generated from a Mathy (https://mathy.ai) code example.\n",
+    "!pip install mathy --upgrade\n",
     "from mathy import envs\n",
     "from mathy.agents.base_config import BaseConfig\n",
     "from mathy.agents.embedding import MathyEmbedding\n",

--- a/libraries/website/docs/snippets/ml/embeddings_rnn_state.ipynb
+++ b/libraries/website/docs/snippets/ml/embeddings_rnn_state.ipynb
@@ -8,8 +8,8 @@
    },
    "outputs": [],
    "source": [
-    "# This file is generated from a mathy documentation code snippet.\n",
-    "!pip install mathy\n",
+    "# This file is generated from a Mathy (https://mathy.ai) code example.\n",
+    "!pip install mathy --upgrade\n",
     "import numpy as np\n",
     "\n",
     "from mathy import envs\n",

--- a/libraries/website/docs/snippets/ml/lists_to_observations.ipynb
+++ b/libraries/website/docs/snippets/ml/lists_to_observations.ipynb
@@ -8,8 +8,8 @@
    },
    "outputs": [],
    "source": [
-    "# This file is generated from a mathy documentation code snippet.\n",
-    "!pip install mathy\n",
+    "# This file is generated from a Mathy (https://mathy.ai) code example.\n",
+    "!pip install mathy --upgrade\n",
     "from mathy import (\n",
     "    MathyEnv,\n",
     "    MathyEnvState,\n",

--- a/libraries/website/docs/snippets/ml/policy_value_basic.ipynb
+++ b/libraries/website/docs/snippets/ml/policy_value_basic.ipynb
@@ -8,8 +8,8 @@
    },
    "outputs": [],
    "source": [
-    "# This file is generated from a mathy documentation code snippet.\n",
-    "!pip install mathy\n",
+    "# This file is generated from a Mathy (https://mathy.ai) code example.\n",
+    "!pip install mathy --upgrade\n",
     "import tensorflow as tf\n",
     "\n",
     "from mathy import envs\n",

--- a/libraries/website/docs/snippets/ml/policy_value_env_features.ipynb
+++ b/libraries/website/docs/snippets/ml/policy_value_env_features.ipynb
@@ -8,8 +8,8 @@
    },
    "outputs": [],
    "source": [
-    "# This file is generated from a mathy documentation code snippet.\n",
-    "!pip install mathy\n",
+    "# This file is generated from a Mathy (https://mathy.ai) code example.\n",
+    "!pip install mathy --upgrade\n",
     "from mathy import envs\n",
     "from mathy.agents.base_config import BaseConfig\n",
     "from mathy.agents.policy_value_model import PolicyValueModel\n",

--- a/libraries/website/docs/snippets/ml/policy_value_serialization.ipynb
+++ b/libraries/website/docs/snippets/ml/policy_value_serialization.ipynb
@@ -8,8 +8,8 @@
    },
    "outputs": [],
    "source": [
-    "# This file is generated from a mathy documentation code snippet.\n",
-    "!pip install mathy\n",
+    "# This file is generated from a Mathy (https://mathy.ai) code example.\n",
+    "!pip install mathy --upgrade\n",
     "!pip install gym\n",
     "import shutil\n",
     "import tempfile\n",

--- a/libraries/website/docs/snippets/ml/text_to_tree.ipynb
+++ b/libraries/website/docs/snippets/ml/text_to_tree.ipynb
@@ -8,8 +8,8 @@
    },
    "outputs": [],
    "source": [
-    "# This file is generated from a mathy documentation code snippet.\n",
-    "!pip install mathy\n",
+    "# This file is generated from a Mathy (https://mathy.ai) code example.\n",
+    "!pip install mathy --upgrade\n",
     "from typing import List\n",
     "\n",
     "from mathy import ExpressionParser, MathExpression, Token, VariableExpression\n",

--- a/libraries/website/docs/snippets/ml/tree_to_list.ipynb
+++ b/libraries/website/docs/snippets/ml/tree_to_list.ipynb
@@ -8,8 +8,8 @@
    },
    "outputs": [],
    "source": [
-    "# This file is generated from a mathy documentation code snippet.\n",
-    "!pip install mathy\n",
+    "# This file is generated from a Mathy (https://mathy.ai) code example.\n",
+    "!pip install mathy --upgrade\n",
     "from typing import List\n",
     "from mathy import ExpressionParser, MathExpression\n",
     "\n",

--- a/libraries/website/docs/snippets/ml/zero_debugging.ipynb
+++ b/libraries/website/docs/snippets/ml/zero_debugging.ipynb
@@ -8,8 +8,8 @@
    },
    "outputs": [],
    "source": [
-    "# This file is generated from a mathy documentation code snippet.\n",
-    "!pip install mathy\n",
+    "# This file is generated from a Mathy (https://mathy.ai) code example.\n",
+    "!pip install mathy --upgrade\n",
     "!pip install gym\n",
     "from mathy.cli import setup_tf_env\n",
     "from mathy.agents.zero import SelfPlayConfig, self_play_runner\n",

--- a/libraries/website/docs/snippets/ml/zero_profiling.ipynb
+++ b/libraries/website/docs/snippets/ml/zero_profiling.ipynb
@@ -1,0 +1,47 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "# This file is generated from a Mathy (https://mathy.ai) code example.\n",
+    "!pip install mathy --upgrade\n",
+    "!pip install gym\n",
+    "import os\n",
+    "import shutil\n",
+    "import tempfile\n",
+    "\n",
+    "from mathy.agents.zero import SelfPlayConfig, self_play_runner\n",
+    "from mathy.cli import setup_tf_env\n",
+    "\n",
+    "model_folder = tempfile.mkdtemp()\n",
+    "args = SelfPlayConfig(\n",
+    "    num_workers=1,\n",
+    "    profile=True,\n",
+    "    model_dir=model_folder,\n",
+    "    # All options below here can be deleted if you're actually training\n",
+    "    max_eps=1,\n",
+    "    self_play_problems=1,\n",
+    "    training_iterations=1,\n",
+    "    epochs=1,\n",
+    "    mcts_sims=3,\n",
+    ")\n",
+    "\n",
+    "self_play_runner(args)\n",
+    "\n",
+    "\n",
+    "assert os.path.isfile(os.path.join(args.model_dir, \"worker_0.profile\"))\n",
+    "\n",
+    "# Comment this out to keep your model\n",
+    "shutil.rmtree(model_folder)"
+   ]
+  }
+ ],
+ "metadata": {},
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/libraries/website/docs/snippets/ml/zero_profiling.py
+++ b/libraries/website/docs/snippets/ml/zero_profiling.py
@@ -1,0 +1,28 @@
+#!pip install gym
+import os
+import shutil
+import tempfile
+
+from mathy.agents.zero import SelfPlayConfig, self_play_runner
+from mathy.cli import setup_tf_env
+
+model_folder = tempfile.mkdtemp()
+args = SelfPlayConfig(
+    num_workers=1,
+    profile=True,
+    model_dir=model_folder,
+    # All options below here can be deleted if you're actually training
+    max_eps=1,
+    self_play_problems=1,
+    training_iterations=1,
+    epochs=1,
+    mcts_sims=3,
+)
+
+self_play_runner(args)
+
+
+assert os.path.isfile(os.path.join(args.model_dir, "worker_0.profile"))
+
+# Comment this out to keep your model
+shutil.rmtree(model_folder)

--- a/libraries/website/docs/snippets/ml/zero_training.ipynb
+++ b/libraries/website/docs/snippets/ml/zero_training.ipynb
@@ -36,7 +36,6 @@
     "    # This is normally larger, try 10\n",
     "    epochs=1,\n",
     "    # This is a tiny model, designed to be fast for testing.\n",
-    "    lstm_units=16,\n",
     "    units=32,\n",
     "    embedding_units=16,\n",
     "    # The number of MCTS sims directly correlates with finding quality\n",

--- a/libraries/website/docs/snippets/ml/zero_training.ipynb
+++ b/libraries/website/docs/snippets/ml/zero_training.ipynb
@@ -8,8 +8,8 @@
    },
    "outputs": [],
    "source": [
-    "# This file is generated from a mathy documentation code snippet.\n",
-    "!pip install mathy\n",
+    "# This file is generated from a Mathy (https://mathy.ai) code example.\n",
+    "!pip install mathy --upgrade\n",
     "!pip install gym\n",
     "from mathy.cli import setup_tf_env\n",
     "\n",

--- a/libraries/website/docs/snippets/ml/zero_training.py
+++ b/libraries/website/docs/snippets/ml/zero_training.py
@@ -24,7 +24,6 @@ self_play_cfg = SelfPlayConfig(
     # This is normally larger, try 10
     epochs=1,
     # This is a tiny model, designed to be fast for testing.
-    lstm_units=16,
     units=32,
     embedding_units=16,
     # The number of MCTS sims directly correlates with finding quality

--- a/libraries/website/docs/snippets/rules/commutative_swap.ipynb
+++ b/libraries/website/docs/snippets/rules/commutative_swap.ipynb
@@ -8,8 +8,8 @@
    },
    "outputs": [],
    "source": [
-    "# This file is generated from a mathy documentation code snippet.\n",
-    "!pip install mathy\n",
+    "# This file is generated from a Mathy (https://mathy.ai) code example.\n",
+    "!pip install mathy --upgrade\n",
     "from mathy import CommutativeSwapRule, ExpressionParser\n",
     "\n",
     "input = \"x + y + x\"\n",

--- a/libraries/website/docs/snippets/use_a_custom_rule.ipynb
+++ b/libraries/website/docs/snippets/use_a_custom_rule.ipynb
@@ -8,8 +8,8 @@
    },
    "outputs": [],
    "source": [
-    "# This file is generated from a mathy documentation code snippet.\n",
-    "!pip install mathy\n",
+    "# This file is generated from a Mathy (https://mathy.ai) code example.\n",
+    "!pip install mathy --upgrade\n",
     "!pip install gym\n",
     "import os\n",
     "import shutil\n",

--- a/libraries/website/tests/ml/test_zero.py
+++ b/libraries/website/tests/ml/test_zero.py
@@ -9,3 +9,7 @@ def test_ml_zero_training():
 def test_ml_zero_debugging():
     from ...docs.snippets.ml import zero_debugging
 
+
+def test_ml_zero_profiling():
+    from ...docs.snippets.ml import zero_profiling
+

--- a/libraries/website/tools/write_ipynb.py
+++ b/libraries/website/tools/write_ipynb.py
@@ -6,8 +6,8 @@ import os
 def render_ipynb(from_file: str, to_file: str):
     # print(f"{from_file} -> {to_file}")
     header = """
-# This file is generated from a mathy documentation code snippet.
-!pip install mathy
+# This file is generated from a Mathy (https://mathy.ai) code example.
+!pip install mathy --upgrade
 """
 
     with open(from_file, "r") as fpin:


### PR DESCRIPTION
The "zero" agent is a bit busted after I brought it back recently. This makes sense because the A3C agent was more recently developed. This addresses some obviously broken bits and gets agent zero back to a decent state.

Changes:
 - [x] Add support for `--profile` with the zero agent when using a single worker.
 - [x] Replace inefficient sequence training with minibatching as in the original paper
 - [x] Add alternative architecture that works with non-temporally ordered batches (`--use-lstm=False`/`SelfPlayConfig(use_lstm=False)`)
     - [x] Revive old `DenseNetStack` and `DenseNetBlock`
     - [x] Alternative embeddings head = `DenseNetStack -> LuongAttention` ... 🤷‍♂ 