### PR TITLE
chore(codecov): ignore patch diff

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,3 @@
+coverage:
+  status:
+    patch: off


### PR DESCRIPTION
 - mathy is a large monorepo, so diffs will often contain code or data that is not directly tested. Testing is aimed at libraries and their specific units of behavior, not at arbitrary code diffs.