### PR TITLE
Change Swarm multiprocessing default on Windows

### DIFF
--- a/libraries/mathy_python/mathy/cli.py
+++ b/libraries/mathy_python/mathy/cli.py
@@ -4,6 +4,7 @@
 Command line application for interacting with Mathy agents and environments.
 """
 
+import os
 import click
 from wasabi import msg
 
@@ -31,7 +32,7 @@ def cli_contribute():
 @click.option(
     "single_process",
     "--single-process",
-    default=False,
+    default=os.name == "nt", # fragile swarm mp is unreliable on windows
     is_flag=True,
     help="Use single-process execution with the swarm solver",
 )

--- a/libraries/mathy_python/requirements.txt
+++ b/libraries/mathy_python/requirements.txt
@@ -7,6 +7,7 @@ typer<0.7.0,>=0.6.1
 wasabi
 mathy_core>=0.8.6,<0.9.0
 mathy_envs[gym]>=0.11.4,<0.12.0
+gym<0.21.0
 fragile==0.0.47
 tqdm>=4.43.0
 # new python feature backports


### PR DESCRIPTION
- The fragile swarm multiprocessing support doesn't appear to work on windows. Set the default value to false when running on an nt platform
- Pin Gym versions to < 0.21.0 to fix swarm step-by-step output