### PR TITLE
feat(swarm): increase solver state size to support longer problems

### DIFF
--- a/libraries/mathy_python/mathy/solver.py
+++ b/libraries/mathy_python/mathy/solver.py
@@ -147,7 +147,7 @@ class FragileEnvironment:
 
     def get_state(self) -> np.ndarray:
         assert self._env.state is not None, "env required to get_state"
-        return self._env.state.to_np(768)
+        return self._env.state.to_np(2048)
 
     def set_state(self, state: np.ndarray):
         assert self._env is not None, "env required to set_state"


### PR DESCRIPTION
 - the env state has to keep the entire move history in its output (to penalize reentrant states, etc.) and the 768 length can be too short on long problems