### PR TITLE
chore(website): fix assocaitive/commutative examples

### DIFF
--- a/libraries/website/docs/lib/styles.css
+++ b/libraries/website/docs/lib/styles.css
@@ -2,6 +2,9 @@
 .md-typeset__table {
   min-width: 100%;
 }
+.md-typeset table:not([class]) {
+  display: table;
+}
 
 .contributors-wrapper .md-typeset__table {
   min-width: 100px;

--- a/libraries/website/docs/rules/associative_property.md
+++ b/libraries/website/docs/rules/associative_property.md
@@ -41,4 +41,4 @@ The formulation of this property is the same for addition and multiplication:
 
 ### Examples
 
-`rule_tests:associative_property`
+`rule_tests:associative_swap`

--- a/libraries/website/docs/rules/commutative_property.md
+++ b/libraries/website/docs/rules/commutative_property.md
@@ -37,4 +37,4 @@ Given a common parent node, this rule switches the order of the children of that
 
 ### Examples
 
-`rule_tests:commutative_property`
+`rule_tests:commutative_swap`


### PR DESCRIPTION
 - they didn't reference the proper rule name to pull examples from